### PR TITLE
Ensure error is thrown when invoking _.chain

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ export default function({ Plugin, types: t }) {
     return selectedMethods[methodName];
   }
 
+  const CHAIN_ERR = 'lodash chaining syntax is not yet supported';
+
   return new Plugin('lodash', {
     visitor: {
 
@@ -65,14 +67,17 @@ export default function({ Plugin, types: t }) {
           importMethod(fpSpecified[name], file);
           node.callee = t.memberExpression(lodashFpIdentifier, t.identifier(fpSpecified[name]));
         }
-        // Detect chaining
+        // Detect chaining via _(value)
         else if (lodashObjs[name]) {
-          throw new Error('lodash chaining syntax is not yet supported');
+          throw new Error(CHAIN_ERR);
         }
       },
 
       MemberExpression(node, parent, scope, file) {
-        if (lodashObjs[node.object.name]) {
+        if (lodashObjs[node.object.name] && node.property.name === 'chain') {
+          // Detect chaining via _.chain(value)
+          throw new Error(CHAIN_ERR);
+        } else if (lodashObjs[node.object.name]) {
           // _.foo() -> _foo()
           return importMethod(node.property.name, file);
         } else if (fpObjs[node.object.name]) {

--- a/test/error-fixtures/chain-method/actual.js
+++ b/test/error-fixtures/chain-method/actual.js
@@ -1,0 +1,5 @@
+import _ from 'lodash';
+
+let result = _.chain([1, 2, 3]).map(function() {
+
+});

--- a/test/index.js
+++ b/test/index.js
@@ -24,7 +24,7 @@ describe("Lodash modularized builds", () => {
   });
 
   fs.readdirSync(errorFixturesDir).map(caseName => {
-    const fixtureDir = path.join(fixturesDir, caseName);
+    const fixtureDir = path.join(errorFixturesDir, caseName);
     const actualFile = path.join(fixtureDir, "actual.js");
 
     it(`should throw an error with ${caseName.split("-").join(" ")}`, () => {


### PR DESCRIPTION
Hey there, I love this plugin :)

However, I got bitten when it transformed a `_.chain(thing)` in our codebase, this PR ensures that an error is thrown when someone calls a chain like that.

Also fixed a copy-paste error which promises that error tests always fail... because it looked for fixtures in the wrong directory :+1: 

I'm just a Lodash enthusiast and I've never written a Babel plugin, I'll be happy to fix anything (however small) if its needed!
